### PR TITLE
Add link to forum discussion in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Macro Joint is a macro to create joints in FreeCAD.  Usage: select a face and ru
 ## Installation
 Now available in the addon manager.  Or you can install by placing the Joint.FCMacro into your macro folder.  On first run it will offer to create a new file called joint.py.  This file is needed for the Joint feature python objects to be parametric and functional upon reloading documents containing these objects.
 
+## Q&A Discussion
+https://forum.freecad.org/viewtopic.php?t=64298
+
 ## Usage
 Select the face upon which you wish to create the joint, and run the macro.  A default joint with editable properties will appear in the tree.  Adjust the properties as desired, then create a mate for this joint on another face of another object.  The Mortise is the mate for the Tenon.  For the Box Joints and Dovetail Joints you will create another of the same type for the mate, setting the Use Odd property to True for the mate, usually.  For Dovetail Joints it might also be necessary to adjust the Angle X property to 90 degrees for the mate so that a good mate can be created.  Mortise, Tenon, and Box Joints are all fairly easy to make.  The Dovetail Joints will require more fiddling, but with some patience a good mate can always be created.
 


### PR DESCRIPTION
Hi, I thought it would be nice to cross-link the forum discussion to the readme so there is a way to go back and forth. 

Feel free to merge, or close. 

Thanks for making this plugin, I am just getting started with FreeCad to make a spice rack box and this is just what I needed when searching the add-on manager for "joint"!